### PR TITLE
v3 data format unit tests (pt. 3)

### DIFF
--- a/code/edgebridge/src/androidTest/java/com/adobe/marketing/mobile/edge/bridge/EdgeBridgeFunctionalTests.java
+++ b/code/edgebridge/src/androidTest/java/com/adobe/marketing/mobile/edge/bridge/EdgeBridgeFunctionalTests.java
@@ -94,13 +94,18 @@ public class EdgeBridgeFunctionalTests {
 		List<TestableNetworkRequest> networkRequests = getNetworkRequestsWith(EDGE_INTERACT_ENDPOINT, HttpMethod.POST);
 		assertEquals(1, networkRequests.size());
 		Map<String, String> requestData = flattenBytes(networkRequests.get(0).getBody());
-		assertEquals(15, requestData.size());
+		assertEquals(17, requestData.size());
 		assertEquals("analytics.track", requestData.get("events[0].xdm.eventType"));
 		assertNotNull(requestData.get("events[0].xdm.timestamp"));
 		assertNotNull(requestData.get("events[0].xdm._id"));
+		assertEquals("foreground", requestData.get("events[0].data.__adobe.analytics.cp"));
 		assertEquals("state name", requestData.get("events[0].data.__adobe.analytics.pageName"));
 		assertEquals("propValue1", requestData.get("events[0].data.__adobe.analytics.c1"));
 		assertEquals("value1", requestData.get("events[0].data.__adobe.analytics.contextData.key1"));
+		assertEquals(
+			"com.adobe.marketing.mobile.edge.bridge.test",
+			requestData.get("events[0].data.__adobe.analytics.contextData.a.AppID")
+		);
 	}
 
 	@Test
@@ -121,14 +126,19 @@ public class EdgeBridgeFunctionalTests {
 		List<TestableNetworkRequest> networkRequests = getNetworkRequestsWith(EDGE_INTERACT_ENDPOINT, HttpMethod.POST);
 		assertEquals(1, networkRequests.size());
 		Map<String, String> requestData = flattenBytes(networkRequests.get(0).getBody());
-		assertEquals(16, requestData.size());
+		assertEquals(18, requestData.size());
 		assertEquals("analytics.track", requestData.get("events[0].xdm.eventType"));
 		assertNotNull(requestData.get("events[0].xdm.timestamp"));
 		assertNotNull(requestData.get("events[0].xdm._id"));
+		assertEquals("foreground", requestData.get("events[0].data.__adobe.analytics.cp"));
 		assertEquals("action name", requestData.get("events[0].data.__adobe.analytics.linkName"));
 		assertEquals("other", requestData.get("events[0].data.__adobe.analytics.linkType"));
 		assertEquals("propValue1", requestData.get("events[0].data.__adobe.analytics.c1"));
 		assertEquals("value1", requestData.get("events[0].data.__adobe.analytics.contextData.key1"));
+		assertEquals(
+			"com.adobe.marketing.mobile.edge.bridge.test",
+			requestData.get("events[0].data.__adobe.analytics.contextData.a.AppID")
+		);
 	}
 
 	@Test
@@ -151,15 +161,20 @@ public class EdgeBridgeFunctionalTests {
 		List<TestableNetworkRequest> networkRequests = getNetworkRequestsWith(EDGE_INTERACT_ENDPOINT, HttpMethod.POST);
 		assertEquals(1, networkRequests.size());
 		Map<String, String> requestData = flattenBytes(networkRequests.get(0).getBody());
-		assertEquals(16, requestData.size());
+		assertEquals(18, requestData.size());
 		assertEquals("analytics.track", requestData.get("events[0].xdm.eventType"));
 		assertNotNull(requestData.get("events[0].xdm.timestamp"));
 		assertNotNull(requestData.get("events[0].xdm._id"));
+		assertEquals("foreground", requestData.get("events[0].data.__adobe.analytics.cp"));
 		assertEquals("Rule Action", requestData.get("events[0].data.__adobe.analytics.linkName"));
 		assertEquals("other", requestData.get("events[0].data.__adobe.analytics.linkType"));
 		assertEquals("Rule State", requestData.get("events[0].data.__adobe.analytics.pageName"));
 		// Data is defined in the rule, not from the dispatched PII event
 		assertEquals("testValue", requestData.get("events[0].data.__adobe.analytics.contextData.testKey"));
+		assertEquals(
+			"com.adobe.marketing.mobile.edge.bridge.test",
+			requestData.get("events[0].data.__adobe.analytics.contextData.a.AppID")
+		);
 	}
 
 	/**

--- a/code/edgebridge/src/test/java/com/adobe/marketing/mobile/edge/bridge/EdgeBridgeExtensionTests.kt
+++ b/code/edgebridge/src/test/java/com/adobe/marketing/mobile/edge/bridge/EdgeBridgeExtensionTests.kt
@@ -146,7 +146,11 @@ class EdgeBridgeExtensionTests {
                 "__adobe" to mapOf(
                     "analytics" to mapOf(
                         "linkName" to "action name",
-                        "linkType" to "other"
+                        "linkType" to "other",
+                        "cp" to "foreground",
+                        "contextData" to mapOf(
+                            "a.AppID" to "null"
+                        )
                     )
                 )
             ),
@@ -179,7 +183,11 @@ class EdgeBridgeExtensionTests {
             "data" to mapOf(
                 "__adobe" to mapOf(
                     "analytics" to mapOf(
-                        "c1" to "propValue1"
+                        "c1" to "propValue1",
+                        "cp" to "foreground",
+                        "contextData" to mapOf(
+                            "a.AppID" to "null"
+                        )
                     )
                 )
             ),
@@ -212,7 +220,11 @@ class EdgeBridgeExtensionTests {
             "data" to mapOf(
                 "__adobe" to mapOf(
                     "analytics" to mapOf(
-                        "c1" to "propValue1"
+                        "c1" to "propValue1",
+                        "cp" to "foreground",
+                        "contextData" to mapOf(
+                            "a.AppID" to "null"
+                        )
                     )
                 )
             ),
@@ -242,7 +254,11 @@ class EdgeBridgeExtensionTests {
             "data" to mapOf(
                 "__adobe" to mapOf(
                     "analytics" to mapOf(
-                        "pageName" to "state name"
+                        "pageName" to "state name",
+                        "cp" to "foreground",
+                        "contextData" to mapOf(
+                            "a.AppID" to "null"
+                        )
                     )
                 )
             ),
@@ -275,7 +291,11 @@ class EdgeBridgeExtensionTests {
             "data" to mapOf(
                 "__adobe" to mapOf(
                     "analytics" to mapOf(
-                        "c1" to "propValue1"
+                        "c1" to "propValue1",
+                        "cp" to "foreground",
+                        "contextData" to mapOf(
+                            "a.AppID" to "null"
+                        )
                     )
                 )
             ),
@@ -308,7 +328,11 @@ class EdgeBridgeExtensionTests {
             "data" to mapOf(
                 "__adobe" to mapOf(
                     "analytics" to mapOf(
-                        "c1" to "propValue1"
+                        "c1" to "propValue1",
+                        "cp" to "foreground",
+                        "contextData" to mapOf(
+                            "a.AppID" to "null"
+                        )
                     )
                 )
             ),
@@ -334,7 +358,15 @@ class EdgeBridgeExtensionTests {
 
         val expectedData = mapOf(
             "data" to mapOf(
-                "__adobe" to mapOf("analytics" to mapOf("c1" to "propValue1"))
+                "__adobe" to mapOf(
+                    "analytics" to mapOf(
+                        "c1" to "propValue1",
+                        "cp" to "foreground",
+                        "contextData" to mapOf(
+                            "a.AppID" to "null"
+                        )
+                    )
+                )
             ),
             "xdm" to mapOf(
                 "eventType" to EdgeBridgeTestConstants.JsonValues.EVENT_TYPE,
@@ -358,7 +390,15 @@ class EdgeBridgeExtensionTests {
 
         val expectedData = mapOf(
             "data" to mapOf(
-                "__adobe" to mapOf("analytics" to mapOf("contextData" to mapOf("key1" to "value1")))
+                "__adobe" to mapOf(
+                    "analytics" to mapOf(
+                        "cp" to "foreground",
+                        "contextData" to mapOf(
+                            "key1" to "value1",
+                            "a.AppID" to "null"
+                        )
+                    )
+                )
             ),
             "xdm" to mapOf(
                 "eventType" to EdgeBridgeTestConstants.JsonValues.EVENT_TYPE,
@@ -457,7 +497,11 @@ class EdgeBridgeExtensionTests {
                         "products" to ";product1;1;5.99;event12=5.99;evar5=merchEvar5,;product2;2;10.99;event13=6;eVar6=mercheVar6",
                         "c1" to "propValue1",
                         "cc" to "USD",
-                        "contextData" to mapOf("key1" to "value1")
+                        "contextData" to mapOf(
+                            "key1" to "value1",
+                            "a.AppID" to "null"
+                        ),
+                        "cp" to "foreground",
                     )
                 ),
                 "key2" to "value2"
@@ -501,7 +545,11 @@ class EdgeBridgeExtensionTests {
                         "events" to "event1,event2,event3,event4,event12,event13",
                         "c1" to "propValue1",
                         "v1" to "evarValue1",
-                        "contextData" to mapOf("key1" to "value1")
+                        "contextData" to mapOf(
+                            "key1" to "value1",
+                            "a.AppID" to "null"
+                        ),
+                        "cp" to "foreground"
                     )
                 ),
                 "key2" to "value2"
@@ -562,7 +610,13 @@ class EdgeBridgeExtensionTests {
         val expectedData = mapOf(
             "data" to mapOf(
                 "__adobe" to mapOf(
-                    "analytics" to mapOf("c1" to "propValue")
+                    "analytics" to mapOf(
+                        "c1" to "propValue",
+                        "cp" to "foreground",
+                        "contextData" to mapOf(
+                            "a.AppID" to "null"
+                        )
+                    )
                 )
             ),
             "xdm" to mapOf(
@@ -614,7 +668,11 @@ class EdgeBridgeExtensionTests {
                         "=" to "value8",
                         "\\" to "value9",
                         "." to "value10",
-                        "?" to "value11"
+                        "?" to "value11",
+                        "cp" to "foreground",
+                        "contextData" to mapOf(
+                            "a.AppID" to "null"
+                        )
                     )
                 )
             ),
@@ -665,8 +723,10 @@ class EdgeBridgeExtensionTests {
                             "\\&&" to "value6",
                             ".&&" to "value7",
                             "?&&" to "value8",
-                            "\n&&" to "value9"
-                        )
+                            "\n&&" to "value9",
+                            "a.AppID" to "null"
+                        ),
+                        "cp" to "foreground"
                     )
                 )
             ),
@@ -708,7 +768,11 @@ class EdgeBridgeExtensionTests {
                 "__adobe" to mapOf(
                     "analytics" to mapOf(
                         "key1" to "",
-                        "contextData" to mapOf("key5" to "")
+                        "contextData" to mapOf(
+                            "key5" to "",
+                            "a.AppID" to "null"
+                        ),
+                        "cp" to "foreground"
                     )
                 )
             ),
@@ -775,7 +839,11 @@ class EdgeBridgeExtensionTests {
                     "analytics" to mapOf(
                         "linkName" to "Test Action",
                         "linkType" to "other",
-                        "contextData" to mapOf("testKey" to "testValue")
+                        "contextData" to mapOf(
+                            "testKey" to "testValue",
+                            "a.AppID" to "null"
+                        ),
+                        "cp" to "foreground"
                     )
                 )
             ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates existing unit tests to incorporate the new data format, and is a continuation of part 2, adding more unit test coverage for the new data format in https://github.com/adobe/aepsdk-edgebridge-android/pull/62

Test cases validate that:
1. Empty string keys are filtered out
2. `null` keys are filtered out
3. Empty string value `""` in `contextdata` context is NOT filtered out
4. `null` value in in `contextdata` context is filtered out
5. `testHandleTrackEvent_mapsNullAndEmptyValues_dispatchesEdgeRequestEvent` updated to only cover top level properties (previous coverage broken up into more granular 1 and 2)
6. Wrong types in event payload are filtered out
    1. **QUESTION**: does this test case capture the correct/desired behavior for the `Map<String, String>` validation logic?

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
